### PR TITLE
Store translation id when comment is made against current translation

### DIFF
--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -135,7 +135,6 @@ class GP_Translation_Helpers {
 			'translation' => $t,
 		);
 
-		$css = $js = '';
 		$sections = array();
 		foreach ( $this->helpers as $translation_helper ) {
 			$translation_helper->set_data( $args );

--- a/helpers-assets/js/translation-discussion.js
+++ b/helpers-assets/js/translation-discussion.js
@@ -18,7 +18,8 @@ jQuery( function( $ ) {
 			content: $commentform.find('textarea[name=comment]').val(),
 			post: $commentform.attr('id').split( '-' )[ 1 ],
 			meta: {
-				locale : $commentform.find('input[name=comment_locale]').val()
+				translation_id : $commentform.find('input[name=translation_id]').val(),
+				locale         : $commentform.find('input[name=comment_locale]').val()
 			}
 		}
 		jQuery.wpcom_proxy_request( {

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -17,6 +17,7 @@
 			'style'       => 'ul',
 			'type'       => 'comment',
 			'callback' => 'gth_discussion_callback',
+			'translation_id' => $translation_id,
 		), $comments );
 		?>
 	</ul><!-- .discussion-list -->

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -27,7 +27,11 @@
 		'title_reply_before'   => '<h6 id="reply-title" class="discuss-title">',
 		'title_reply_after'    => '</h6>',
 		'id_form'              => 'commentform-' . $post_id,
-		'comment_notes_after' => '<input type="hidden" name="comment_locale" value="' . esc_attr( $locale_slug ) . '" />'
+		'comment_notes_after'  => implode( "\n",
+			array(
+				'<input type="hidden" name="comment_locale" value="' . esc_attr( $locale_slug ) . '" />',
+				'<input type="hidden" name="translation_id" value="' . esc_attr( $translation_id ) . '" />',
+			) ),
 	), $post_id);
 	?>
 </div><!-- .discussion-wrapper -->

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -189,6 +189,8 @@ function gth_discussion_callback( $comment, $args, $depth ) {
 	$GLOBALS['comment'] = $comment;
 
 	$comment_locale = get_comment_meta( $comment->comment_ID, 'locale', true );
+	$current_translation_id = $args['translation_id'];
+	$comment_translation_id = get_comment_meta( $comment->comment_ID, 'translation_id', true );
 	?>
 <li class="<?php echo esc_attr( 'comment-locale-' . $comment_locale );?>">
 	<article id="comment-<?php comment_ID(); ?>" class="comment">
@@ -231,6 +233,10 @@ function gth_discussion_callback( $comment, $args, $depth ) {
 			</div><!-- .comment-author .vcard -->
 			<?php if ( $comment->comment_approved == '0' ) : ?>
 				<em><?php _e( 'Your comment is awaiting moderation.' ); ?></em>
+			<?php endif; ?>
+			<?php if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) : ?>
+				<?php $translation = GP::$translation->get( $comment_translation_id ); ?>
+				<em>Translation: <?php echo esc_translation( $translation->translation_0 );?></em>
 			<?php endif; ?>
 		</footer>
 	</article><!-- #comment-## -->

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -46,13 +46,17 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 		register_post_type( self::POST_TYPE, $post_type_args );
 
-		$rest_meta_args = array(
+		register_meta( 'comment', 'translation_id', array(
+			'description'  => 'Translation that was displayed when the comment was posted',
+			'single'       => true,
+			'show_in_rest' => true,
+		) );
+
+		register_meta( 'comment', 'locale', array(
 			'description'  => 'Locale slug associated with a string comment',
 			'single'       => true,
 			'show_in_rest' => true,
-		);
-
-		register_meta( 'comment', 'locale', $rest_meta_args );
+		) );
 	}
 
 	public function comment_moderation( $approved, $commentdata ) {
@@ -157,6 +161,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			array(
 				'comments' => $comments,
 				'post_id' => self::get_shadow_post( $this->data['original_id'] ),
+				'translation_id' => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
 				'locale_slug' => $this->data['locale_slug'],
 			),
 			$this->assets_dir . 'templates'


### PR DESCRIPTION
Store the translation id (if any) that wast displayed next to the comment form. Helps understand the context in which the comment was made.

Display the translation (singular, should be enough) if the currently displayed translation is not the one that was displayed when the comment was made
![screen shot 2017-03-23 at 14 53 07](https://cloud.githubusercontent.com/assets/844866/24248581/b0ef2280-0fd8-11e7-991d-b9c360ab5ee0.png)

Fixes #3 
